### PR TITLE
ci: psr-12 support in config cs-fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
+        '@PSR12' => true,
         '@PSR2' => true,
+        '@PSR1' => true,
         'array_syntax' => [
             'syntax' => 'short',
         ],


### PR DESCRIPTION
## What is the current behavior?
* Not contains config psr-12 in `php-cs-fixer.php` file.

## What is the new behavior?
* Added psr-12 in `php-cs-fixer.php` file to follow recommendation https://www.php-fig.org/psr/psr-12/

## Other information
![image](https://github.com/jonas-elias/banking/assets/48037643/098fffe3-573b-4ef1-88b9-e3411c9d06f7)