### PR TITLE
feat: transaction module

### DIFF
--- a/app/Domain/Transaction/Controller/TransactionController.php
+++ b/app/Domain/Transaction/Controller/TransactionController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\Controller;
+
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Exception\PayeeException;
+use App\Domain\Transaction\Exception\PayerException;
+use App\Domain\Transaction\Service\TransactionService;
+use App\Request\RequestInterface;
+use App\Response\ResponseInterface;
+use Hyperf\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
+use Throwable;
+
+/**
+ * Class transaction controller to call service transaction.
+ */
+class TransactionController
+{
+    /**
+     * Method constructor.
+     *
+     * @param TransactionService $transactionService
+     *
+     * @return void
+     */
+    public function __construct(
+        protected TransactionService $transactionService
+    ) {
+    }
+
+    /**
+     * Transfer controller method call service.
+     *
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
+     * @param TransactionDTO    $transactionDTO
+     *
+     * @return Psr7ResponseInterface
+     */
+    public function transfer(RequestInterface $request, ResponseInterface $response, TransactionDTO $transactionDTO): Psr7ResponseInterface
+    {
+        try {
+            $dto = $transactionDTO::fromRequest($request);
+
+            $data = $this->transactionService->transfer($dto);
+
+            return $response
+                ->json($data)
+                ->withStatus(200);
+        } catch (ValidationException $th) {
+            return $response->json($th->errors())
+                ->withStatus(422);
+        } catch (PayerException | PayeeException $pe) {
+            return $response->json(['errors' => 'User(s) invalid identification.'])
+                ->withStatus(422);
+        } catch (Throwable $th) {
+            return $response->json(['errors' => $th->getMessage()])
+                ->withStatus(500);
+        }
+    }
+}

--- a/app/Domain/Transaction/DTO/TransactionDTO.php
+++ b/app/Domain/Transaction/DTO/TransactionDTO.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\DTO;
+
+use App\DTO\BaseDTO;
+use FriendsOfHyperf\ValidatedDTO\Casting\IntegerCast;
+
+/**
+ * Class DTO to transaction get params and basic validations.
+ */
+class TransactionDTO extends BaseDTO
+{
+    /**
+     * @var string
+     *             The payer ulid.
+     */
+    public string $payer;
+
+    /**
+     * @var string
+     *             The payee ulid.
+     */
+    public string $payee;
+
+    /**
+     * @var int
+     *          The value in cents.
+     */
+    public int $value;
+
+    /**
+     * Define the validation messages for each field.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            'payer.required' => 'The payer field is required.',
+            'payer.string'   => 'The payer field must be a string.',
+            'payee.required'  => 'The payee field is required.',
+            'payee.string'    => 'The payee field must be a string.',
+            'value.required'  => 'The value field is required.',
+            'value.integer'   => 'The value field must be an integer.',
+            'value.min'       => 'The value field must be at least 1 cent.',
+        ];
+    }
+
+    /**
+     * Define the default values for each field.
+     *
+     * @return array
+     */
+    public function defaults(): array
+    {
+        return [];
+    }
+
+    /**
+     * Define the validation rules for each field.
+     *
+     * @return array
+     */
+    protected function rules(): array
+    {
+        return [
+            'payer'   => ['required', 'string'],
+            'payee'    => ['required', 'string'],
+            'value'    => ['required', 'integer', 'min:1'],
+        ];
+    }
+
+    /**
+     * Define the cast types for each field.
+     *
+     * @return array
+     */
+    protected function casts(): array
+    {
+        return [
+            'value' => new IntegerCast(),
+        ];
+    }
+}

--- a/app/Domain/Transaction/Exception/PayeeException.php
+++ b/app/Domain/Transaction/Exception/PayeeException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\Exception;
+
+use Exception;
+
+/**
+ * Payee agent exception class.
+ */
+class PayeeException extends Exception
+{
+}

--- a/app/Domain/Transaction/Exception/PayerException.php
+++ b/app/Domain/Transaction/Exception/PayerException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\Exception;
+
+use Exception;
+
+/**
+ * Payer agent exception class.
+ */
+class PayerException extends Exception
+{
+}

--- a/app/Domain/Transaction/Repository/TransactionRepository.php
+++ b/app/Domain/Transaction/Repository/TransactionRepository.php
@@ -37,8 +37,8 @@ class TransactionRepository
 
         $data = $this->transaction::create([
             'id'       => $ulid,
-            'payer_id'     => $transactionDTO->payer,
-            'payee_id'    => $transactionDTO->payee,
+            'payer_id' => $transactionDTO->payer,
+            'payee_id' => $transactionDTO->payee,
             'value'    => $transactionDTO->value,
         ]);
 

--- a/app/Domain/Transaction/Repository/TransactionRepository.php
+++ b/app/Domain/Transaction/Repository/TransactionRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\Repository;
+
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Transaction;
+
+/**
+ * Transaction repository class to create transaction of money in database.
+ */
+class TransactionRepository
+{
+    /**
+     * Method constructor.
+     *
+     * @param Transaction $transaction
+     *
+     * @return void
+     */
+    public function __construct(
+        protected Transaction $transaction,
+    ) {
+    }
+
+    /**
+     * Call database model of the transaction money.
+     *
+     * @param TransactionDTO $transactionDTO
+     *
+     * @return array
+     */
+    public function create(TransactionDTO $transactionDTO): array
+    {
+        $ulid = $this->transaction->newUniqueId();
+
+        $data = $this->transaction::create([
+            'id'       => $ulid,
+            'payer_id'     => $transactionDTO->payer,
+            'payee_id'    => $transactionDTO->payee,
+            'value'    => $transactionDTO->value,
+        ]);
+
+        return [
+            'transaction' => $data->id,
+        ];
+    }
+}

--- a/app/Domain/Transaction/Service/TransactionService.php
+++ b/app/Domain/Transaction/Service/TransactionService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction\Service;
+
+use App\Database\DatabaseTransaction;
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Exception\PayeeException;
+use App\Domain\Transaction\Exception\PayerException;
+use App\Domain\Transaction\Repository\TransactionRepository;
+use App\Domain\User\Repository\UserRepository;
+
+/**
+ * Transaction service class to call repository transaction class and manage business rule.
+ */
+class TransactionService
+{
+    /**
+     * Method constructor.
+     *
+     * @param DatabaseTransaction   $databaseTransaction
+     * @param TransactionRepository $transRepository
+     * @param UserRepository        $userRepository
+     *
+     * @return void
+     */
+    public function __construct(
+        protected DatabaseTransaction $databaseTransaction,
+        protected TransactionRepository $transRepository,
+        protected UserRepository $userRepository,
+    ) {
+    }
+
+    /**
+     * Method to manage business rule of transference money.
+     *
+     * @param TransactionDTO $transactionDTO
+     *
+     * @return void
+     */
+    public function transfer(TransactionDTO $transactionDTO): void
+    {
+        $this->databaseTransaction->executeTransaction(function () use ($transactionDTO) {
+            $data = $this->userRepository->findUsersByIds([$transactionDTO->payer, $transactionDTO->payee]);
+
+            $payer = $data[$transactionDTO->payer] ?? throw new PayerException();
+            $payee = $data[$transactionDTO->payee] ?? throw new PayeeException();
+
+            $payer->debit($transactionDTO->value);
+            $payee->credit($transactionDTO->value);
+
+            $this->userRepository->save($payer);
+            $this->userRepository->save($payee);
+            $this->transRepository->create($transactionDTO);
+        });
+    }
+}

--- a/app/Domain/Transaction/Transaction.php
+++ b/app/Domain/Transaction/Transaction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Transaction;
+
+use App\Model\Model;
+use Hyperf\Database\Model\Concerns\HasUlids;
+
+/**
+ * Model to represent transaction table.
+ */
+class Transaction extends Model
+{
+    use HasUlids;
+
+    /**
+     * The table associated with the model.
+     */
+    protected ?string $table = 'transaction';
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected array $fillable = [
+        'id',
+        'payer_id',
+        'payee_id',
+        'value',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected array $casts = ['created_at' => 'datetime', 'updated_at' => 'datetime'];
+}

--- a/app/Domain/User/Exception/BalanceException.php
+++ b/app/Domain/User/Exception/BalanceException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+use Exception;
+
+/**
+ * Exception class to throw when balance < value.
+ */
+class BalanceException extends Exception
+{
+}

--- a/app/Domain/User/Exception/UserDebitException.php
+++ b/app/Domain/User/Exception/UserDebitException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+use Exception;
+
+/**
+ * Exception class to throw when user cannot debit balance.
+ */
+class UserDebitException extends Exception
+{
+}

--- a/app/Domain/User/Merchant.php
+++ b/app/Domain/User/Merchant.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Domain\User;
 
+use App\Domain\User\Exception\UserDebitException;
+
 /**
  * Model to represent user type merchant.
  */
@@ -16,4 +18,16 @@ class Merchant extends User
     protected array $attributes = [
         'type' => UserType::Merchant->value,
     ];
+
+    /**
+     * Method to increase value in balance.
+     *
+     * @param int $value
+     *
+     * @return User
+     */
+    public function debit(int $value): User
+    {
+        throw new UserDebitException();
+    }
 }

--- a/app/Domain/User/Repository/UserRepository.php
+++ b/app/Domain/User/Repository/UserRepository.php
@@ -63,15 +63,38 @@ class UserRepository
     }
 
     /**
+     * Save user model based in change values received in param.
+     *
+     * @param User $user
+     *
+     * @return void
+     */
+    public function save(User $user): void
+    {
+        $user->save();
+    }
+
+    /**
      * Find users by ids.
      *
      * @param array $ids
      *
-     * @return User
+     * @return array<User>
      */
-    public function findUsersByIds(array $ids): User
+    public function findUsersByIds(array $ids): array
     {
-        return $this->user::query()->whereIn($ids)->sharedLock()->get();
+        $users = $this->user::query()
+            ->whereIn('id', $ids)
+            ->sharedLock()
+            ->get();
+
+        $mappedUsers = [];
+
+        foreach ($users as $user) {
+            $mappedUsers[$user->id] = $user;
+        }
+
+        return $mappedUsers;
     }
 
     /**

--- a/app/Domain/User/User.php
+++ b/app/Domain/User/User.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\Domain\User;
 
+use App\Domain\User\Exception\BalanceException;
 use App\Model\Model;
+use Hyperf\Database\Model\Concerns\HasUlids;
 
 /**
  * Model to represent user single-table model.
  */
 class User extends Model
 {
+    use HasUlids;
+
     /**
      * The table associated with the model.
      */
@@ -32,4 +36,36 @@ class User extends Model
      * The attributes that should be cast to native types.
      */
     protected array $casts = ['created_at' => 'datetime', 'updated_at' => 'datetime'];
+
+    /**
+     * Method to increase value in balance.
+     *
+     * @param int $value
+     *
+     * @return User
+     */
+    public function credit(int $value): User
+    {
+        $this->balance += $value;
+
+        return $this;
+    }
+
+    /**
+     * Method to decrease value in balance.
+     *
+     * @param int $value
+     *
+     * @return User
+     */
+    public function debit(int $value): User
+    {
+        if ($value > $this->balance) {
+            throw new BalanceException();
+        }
+
+        $this->balance -= $value;
+
+        return $this;
+    }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
 
+use App\Domain\Transaction\Controller\TransactionController;
 use App\Domain\User\Controller\UserController;
 use Hyperf\HttpServer\Router\Router;
 
 Router::post('/api/user/register', [UserController::class, 'register']);
+Router::post('/api/transfer', [TransactionController::class, 'transfer']);

--- a/migrations/2024_06_22_165629_create_transaction_table.php
+++ b/migrations/2024_06_22_165629_create_transaction_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Hyperf\Database\Migrations\Migration;
+use Hyperf\Database\Schema\Blueprint;
+use Hyperf\Database\Schema\Schema;
+
+class CreateTransactionTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('transaction', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('payer_id')->references('id')->on('user');
+            $table->foreignUlid('payee_id')->references('id')->on('user');
+            // defined in cents
+            $table->integer('value');
+            $table->datetimes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction');
+    }
+}

--- a/test/Domain/Transaction/Controller/TransactionControllerTest.php
+++ b/test/Domain/Transaction/Controller/TransactionControllerTest.php
@@ -10,12 +10,13 @@ use App\Domain\Transaction\Exception\PayerException;
 use App\Domain\Transaction\Service\TransactionService;
 use App\Request\RequestInterface;
 use App\Response\ResponseInterface;
+use Exception;
 use Hyperf\Validation\ValidationException;
-use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 use Mockery;
 use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 
 class TransactionControllerTest extends TestCase
 {
@@ -108,7 +109,7 @@ class TransactionControllerTest extends TestCase
         $transactionDTO->value = 100;
 
         $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturnSelf();
-        $transactionService->shouldReceive('transfer')->with($transactionDTO)->andThrow(new \Exception('General error'));
+        $transactionService->shouldReceive('transfer')->with($transactionDTO)->andThrow(new Exception('General error'));
 
         $response->shouldReceive('json')->with(['errors' => 'General error'])->andReturnSelf();
         $response->shouldReceive('withStatus')->with(500)->andReturnSelf();
@@ -131,8 +132,7 @@ class TransactionControllerTest extends TestCase
 
     protected function createResponseMock(): ResponseInterface|LegacyMockInterface|MockInterface
     {
-        $mock = Mockery::mock(ResponseInterface::class, Psr7ResponseInterface::class);
-        return $mock;
+        return Mockery::mock(ResponseInterface::class, Psr7ResponseInterface::class);
     }
 
     protected function createTransactionDTOMock(): TransactionDTO|LegacyMockInterface|MockInterface

--- a/test/Domain/Transaction/Controller/TransactionControllerTest.php
+++ b/test/Domain/Transaction/Controller/TransactionControllerTest.php
@@ -4,37 +4,139 @@ declare(strict_types=1);
 
 namespace HyperfTest\Domain\Transaction\Controller;
 
+use App\Domain\Transaction\Controller\TransactionController;
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Exception\PayerException;
+use App\Domain\Transaction\Service\TransactionService;
+use App\Request\RequestInterface;
+use App\Response\ResponseInterface;
+use Hyperf\Validation\ValidationException;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
+use Mockery;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 
 class TransactionControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     protected function tearDown(): void
     {
+        Mockery::close();
         parent::tearDown();
     }
 
     public function testTransactionControllerTransferSuccessful(): void
     {
-        $this->assertTrue(true);
+        $transactionService = $this->createTransactionServiceMock();
+        $request = $this->createRequestMock();
+        $response = $this->createResponseMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturnSelf();
+        $transactionService->shouldReceive('transfer')->with($transactionDTO)->andReturn(['success' => true]);
+
+        $response->shouldReceive('json')->with(null)->andReturnSelf();
+        $response->shouldReceive('withStatus')->with(200)->andReturnSelf();
+
+        $controller = new TransactionController($transactionService);
+        $result = $controller->transfer($request, $response, $transactionDTO);
+
+        $this->assertInstanceOf(Psr7ResponseInterface::class, $result);
     }
 
     public function testTransactionControllerTransferValidationException(): void
     {
-        $this->assertTrue(true);
+        $transactionService = $this->createTransactionServiceMock();
+        $request = $this->createRequestMock();
+        $response = $this->createResponseMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $exception = Mockery::mock(ValidationException::class);
+        $exception->shouldReceive('errors')->andReturn(['error' => 'Validation error']);
+
+        $transactionDTO->shouldReceive('fromRequest')->with($request)->andThrow($exception);
+
+        $response->shouldReceive('json')->with(['error' => 'Validation error'])->andReturnSelf();
+        $response->shouldReceive('withStatus')->with(422)->andReturnSelf();
+
+        $controller = new TransactionController($transactionService);
+        $result = $controller->transfer($request, $response, $transactionDTO);
+
+        $this->assertInstanceOf(Psr7ResponseInterface::class, $result);
     }
 
     public function testTransactionControllerTransferPayerOrPayeeException(): void
     {
-        $this->assertTrue(true);
+        $transactionService = $this->createTransactionServiceMock();
+        $request = $this->createRequestMock();
+        $response = $this->createResponseMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturn($transactionDTO);
+        $transactionService->shouldReceive('transfer')->with($transactionDTO)->andThrow(PayerException::class);
+
+        $response->shouldReceive('json')->with(['errors' => 'User(s) invalid identification.'])->andReturnSelf();
+        $response->shouldReceive('withStatus')->with(422)->andReturnSelf();
+
+        $controller = new TransactionController($transactionService);
+        $result = $controller->transfer($request, $response, $transactionDTO);
+
+        $this->assertInstanceOf(Psr7ResponseInterface::class, $result);
     }
 
     public function testTransactionControllerTransferGeneralException(): void
     {
-        $this->assertTrue(true);
+        $transactionService = $this->createTransactionServiceMock();
+        $request = $this->createRequestMock();
+        $response = $this->createResponseMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturnSelf();
+        $transactionService->shouldReceive('transfer')->with($transactionDTO)->andThrow(new \Exception('General error'));
+
+        $response->shouldReceive('json')->with(['errors' => 'General error'])->andReturnSelf();
+        $response->shouldReceive('withStatus')->with(500)->andReturnSelf();
+
+        $controller = new TransactionController($transactionService);
+        $result = $controller->transfer($request, $response, $transactionDTO);
+
+        $this->assertInstanceOf(Psr7ResponseInterface::class, $result);
+    }
+
+    protected function createTransactionServiceMock(): TransactionService|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(TransactionService::class);
+    }
+
+    protected function createRequestMock(): RequestInterface|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(RequestInterface::class);
+    }
+
+    protected function createResponseMock(): ResponseInterface|LegacyMockInterface|MockInterface
+    {
+        $mock = Mockery::mock(ResponseInterface::class, Psr7ResponseInterface::class);
+        return $mock;
+    }
+
+    protected function createTransactionDTOMock(): TransactionDTO|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(TransactionDTO::class);
     }
 }

--- a/test/Domain/Transaction/Controller/TransactionControllerTest.php
+++ b/test/Domain/Transaction/Controller/TransactionControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Domain\Transaction\Controller;
+
+use PHPUnit\Framework\TestCase;
+
+class TransactionControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testTransactionControllerTransferSuccessful(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionControllerTransferValidationException(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionControllerTransferPayerOrPayeeException(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionControllerTransferGeneralException(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/Domain/Transaction/DTO/TransactionDTOTest.php
+++ b/test/Domain/Transaction/DTO/TransactionDTOTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Domain\Transaction\DTO;
+
+use PHPUnit\Framework\TestCase;
+
+class TransactionDTOTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testTransactionDTOValidationRules(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionDTOValidationMessages(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionDTOCastTypes(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionDTODefaults(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/Domain/Transaction/DTO/TransactionDTOTest.php
+++ b/test/Domain/Transaction/DTO/TransactionDTOTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace HyperfTest\Domain\Transaction\DTO;
 
+use App\Domain\Transaction\DTO\TransactionDTO;
+use FriendsOfHyperf\ValidatedDTO\Casting\IntegerCast;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class TransactionDTOTest extends TestCase
 {
@@ -18,23 +21,77 @@ class TransactionDTOTest extends TestCase
         parent::tearDown();
     }
 
+    private function getProtectedMethod(TransactionDTO $dto, string $methodName)
+    {
+        $reflector = new ReflectionClass($dto);
+        $method = $reflector->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method;
+    }
+
     public function testTransactionDTOValidationRules(): void
     {
-        $this->assertTrue(true);
+        $dto = new TransactionDTO([
+            'payer' => 'test_payer',
+            'payee' => 'test_payee',
+            'value' => 100,
+        ]);
+
+        $rulesMethod = $this->getProtectedMethod($dto, 'rules');
+        $rules = $rulesMethod->invoke($dto);
+
+        $this->assertSame([
+            'payer' => ['required', 'string'],
+            'payee' => ['required', 'string'],
+            'value' => ['required', 'integer', 'min:1'],
+        ], $rules);
     }
 
     public function testTransactionDTOValidationMessages(): void
     {
-        $this->assertTrue(true);
+        $dto = new TransactionDTO([
+            'payer' => 'test_payer',
+            'payee' => 'test_payee',
+            'value' => 100,
+        ]);
+
+        $messages = $dto->messages();
+
+        $this->assertSame([
+            'payer.required' => 'The payer field is required.',
+            'payer.string' => 'The payer field must be a string.',
+            'payee.required' => 'The payee field is required.',
+            'payee.string' => 'The payee field must be a string.',
+            'value.required' => 'The value field is required.',
+            'value.integer' => 'The value field must be an integer.',
+            'value.min' => 'The value field must be at least 1 cent.',
+        ], $messages);
     }
 
     public function testTransactionDTOCastTypes(): void
     {
-        $this->assertTrue(true);
+        $dto = new TransactionDTO([
+            'payer' => 'test_payer',
+            'payee' => 'test_payee',
+            'value' => 100,
+        ]);
+
+        $castsMethod = $this->getProtectedMethod($dto, 'casts');
+        $casts = $castsMethod->invoke($dto);
+
+        $this->assertInstanceOf(IntegerCast::class, $casts['value']);
     }
 
     public function testTransactionDTODefaults(): void
     {
-        $this->assertTrue(true);
+        $dto = new TransactionDTO([
+            'payer' => 'test_payer',
+            'payee' => 'test_payee',
+            'value' => 100,
+        ]);
+
+        $defaults = $dto->defaults();
+
+        $this->assertSame([], $defaults);
     }
 }

--- a/test/Domain/Transaction/DTO/TransactionDTOTest.php
+++ b/test/Domain/Transaction/DTO/TransactionDTOTest.php
@@ -21,14 +21,6 @@ class TransactionDTOTest extends TestCase
         parent::tearDown();
     }
 
-    private function getProtectedMethod(TransactionDTO $dto, string $methodName)
-    {
-        $reflector = new ReflectionClass($dto);
-        $method = $reflector->getMethod($methodName);
-        $method->setAccessible(true);
-        return $method;
-    }
-
     public function testTransactionDTOValidationRules(): void
     {
         $dto = new TransactionDTO([
@@ -93,5 +85,13 @@ class TransactionDTOTest extends TestCase
         $defaults = $dto->defaults();
 
         $this->assertSame([], $defaults);
+    }
+
+    private function getProtectedMethod(TransactionDTO $dto, string $methodName)
+    {
+        $reflector = new ReflectionClass($dto);
+        $method = $reflector->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method;
     }
 }

--- a/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
+++ b/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
@@ -47,7 +47,7 @@ class TransactionRepositoryTest extends TestCase
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('transaction', $result);
-        $this->assertEquals('unique-id', $result['transaction']);
+        $this->assertSame('unique-id', $result['transaction']);
     }
 
     protected function createTransactionDTOMock(): TransactionDTO|LegacyMockInterface|MockInterface

--- a/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
+++ b/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Domain\Transaction\Repository;
+
+use PHPUnit\Framework\TestCase;
+
+class TransactionRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testTransactionRepositoryCreate(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
+++ b/test/Domain/Transaction/Repository/TransactionRepositoryTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace HyperfTest\Domain\Transaction\Repository;
 
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Repository\TransactionRepository;
+use App\Domain\Transaction\Transaction;
+use Mockery;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class TransactionRepositoryTest extends TestCase
@@ -15,11 +21,47 @@ class TransactionRepositoryTest extends TestCase
 
     protected function tearDown(): void
     {
+        Mockery::close();
         parent::tearDown();
     }
 
     public function testTransactionRepositoryCreate(): void
     {
-        $this->assertTrue(true);
+        $transactionDTO = $this->createTransactionDTOMock();
+
+        $transactionMock = $this->createTransactionMock();
+        $transactionRepository = new TransactionRepository($transactionMock);
+
+        $transactionMock->shouldReceive('newUniqueId')
+            ->andReturn('unique-id');
+        $transactionMock->shouldReceive('create')
+            ->with([
+                'id' => 'unique-id',
+                'payer_id' => 'payer_id',
+                'payee_id' => 'payee_id',
+                'value' => 100,
+            ])
+            ->andReturn((object) ['id' => 'unique-id']);
+
+        $result = $transactionRepository->create($transactionDTO);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('transaction', $result);
+        $this->assertEquals('unique-id', $result['transaction']);
+    }
+
+    protected function createTransactionDTOMock(): TransactionDTO|LegacyMockInterface|MockInterface
+    {
+        $transactionDTO = Mockery::mock(TransactionDTO::class);
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        return $transactionDTO;
+    }
+
+    protected function createTransactionMock(): Transaction|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(Transaction::class);
     }
 }

--- a/test/Domain/Transaction/Service/TransactionServiceTest.php
+++ b/test/Domain/Transaction/Service/TransactionServiceTest.php
@@ -4,6 +4,18 @@ declare(strict_types=1);
 
 namespace HyperfTest\Domain\Transaction\Service;
 
+use App\Database\DatabaseTransaction;
+use App\Domain\Transaction\DTO\TransactionDTO;
+use App\Domain\Transaction\Exception\PayeeException;
+use App\Domain\Transaction\Exception\PayerException;
+use App\Domain\Transaction\Repository\TransactionRepository;
+use App\Domain\Transaction\Service\TransactionService;
+use App\Domain\User\Repository\UserRepository;
+use App\Domain\User\User;
+use Exception;
+use Mockery;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 
 class TransactionServiceTest extends TestCase
@@ -15,26 +27,156 @@ class TransactionServiceTest extends TestCase
 
     protected function tearDown(): void
     {
+        Mockery::close();
         parent::tearDown();
     }
 
     public function testTransactionServiceTransferSuccessful(): void
     {
+        $databaseTransaction = $this->createDatabaseTransactionMock();
+        $userRepository = $this->createUserRepositoryMock();
+        $transRepository = $this->createTransactionRepositoryMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+        $user = $this->createUserMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $databaseTransaction->shouldReceive('executeTransaction')->andReturnUsing(function ($callable) {
+            $callable();
+        });
+        $userRepository->shouldReceive('findUsersByIds')
+            ->with([$transactionDTO->payer, $transactionDTO->payee])
+            ->andReturn([$transactionDTO->payer => $user, $transactionDTO->payee => $user]);
+        $user->shouldReceive('debit')->andReturnSelf();
+        $user->shouldReceive('credit')->andReturnSelf();
+        $userRepository->shouldReceive('save')->andReturnSelf();
+        $transRepository->shouldReceive('create')->andReturn([
+            'transaction' => 'transaction-id',
+        ]);
+
+        $service = new TransactionService($databaseTransaction, $transRepository, $userRepository);
+
+        $service->transfer($transactionDTO);
         $this->assertTrue(true);
     }
 
     public function testTransactionServiceTransferPayerException(): void
     {
-        $this->assertTrue(true);
+        $databaseTransaction = $this->createDatabaseTransactionMock();
+        $userRepository = $this->createUserRepositoryMock();
+        $transRepository = $this->createTransactionRepositoryMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+        $user = $this->createUserMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $databaseTransaction->shouldReceive('executeTransaction')->andReturnUsing(function ($callable) {
+            $callable();
+        });
+        $userRepository->shouldReceive('findUsersByIds')
+            ->with([$transactionDTO->payer, $transactionDTO->payee])
+            ->andReturn([$transactionDTO->payee => $user]);
+        $user->shouldReceive('debit')->andReturnSelf();
+        $user->shouldReceive('credit')->andReturnSelf();
+        $userRepository->shouldReceive('save')->andReturnSelf();
+        $transRepository->shouldReceive('create')->andReturn([
+            'transaction' => 'transaction-id',
+        ]);
+
+        $service = new TransactionService($databaseTransaction, $transRepository, $userRepository);
+
+        $this->expectException(PayerException::class);
+        $service->transfer($transactionDTO);
     }
 
     public function testTransactionServiceTransferPayeeException(): void
     {
-        $this->assertTrue(true);
+        $databaseTransaction = $this->createDatabaseTransactionMock();
+        $userRepository = $this->createUserRepositoryMock();
+        $transRepository = $this->createTransactionRepositoryMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+        $user = $this->createUserMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $databaseTransaction->shouldReceive('executeTransaction')->andReturnUsing(function ($callable) {
+            $callable();
+        });
+        $userRepository->shouldReceive('findUsersByIds')
+            ->with([$transactionDTO->payer, $transactionDTO->payee])
+            ->andReturn([$transactionDTO->payer => $user]);
+        $user->shouldReceive('debit')->andReturnSelf();
+        $user->shouldReceive('credit')->andReturnSelf();
+        $userRepository->shouldReceive('save')->andReturnSelf();
+        $transRepository->shouldReceive('create')->andReturn([
+            'transaction' => 'transaction-id',
+        ]);
+
+        $service = new TransactionService($databaseTransaction, $transRepository, $userRepository);
+
+        $this->expectException(PayeeException::class);
+        $service->transfer($transactionDTO);
     }
 
     public function testTransactionServiceTransferGeneralException(): void
     {
-        $this->assertTrue(true);
+        $databaseTransaction = $this->createDatabaseTransactionMock();
+        $userRepository = $this->createUserRepositoryMock();
+        $transRepository = $this->createTransactionRepositoryMock();
+        $transactionDTO = $this->createTransactionDTOMock();
+        $user = $this->createUserMock();
+
+        $transactionDTO->payer = 'payer_id';
+        $transactionDTO->payee = 'payee_id';
+        $transactionDTO->value = 100;
+
+        $databaseTransaction->shouldReceive('executeTransaction')->andReturnUsing(function ($callable) {
+            $callable();
+        });
+        $userRepository->shouldReceive('findUsersByIds')
+            ->with([$transactionDTO->payer, $transactionDTO->payee])
+            ->andReturn([$transactionDTO->payer => $user, $transactionDTO->payee => $user]);
+        $user->shouldReceive('debit')->andReturnSelf();
+        $user->shouldReceive('credit')->andReturnSelf();
+        $userRepository->shouldReceive('save')->andReturnSelf();
+        $transRepository->shouldReceive('create')->andReturnUsing(function () {
+            throw new Exception();
+        });
+
+        $service = new TransactionService($databaseTransaction, $transRepository, $userRepository);
+
+        $this->expectException(Exception::class);
+        $service->transfer($transactionDTO);
+    }
+
+    protected function createDatabaseTransactionMock(): DatabaseTransaction|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(DatabaseTransaction::class);
+    }
+
+    protected function createTransactionRepositoryMock(): TransactionRepository|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(TransactionRepository::class);
+    }
+
+    protected function createUserRepositoryMock(): UserRepository|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(UserRepository::class);
+    }
+
+    protected function createTransactionDTOMock(): TransactionDTO|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(TransactionDTO::class);
+    }
+
+    protected function createUserMock(): User|LegacyMockInterface|MockInterface
+    {
+        return Mockery::mock(User::class);
     }
 }

--- a/test/Domain/Transaction/Service/TransactionServiceTest.php
+++ b/test/Domain/Transaction/Service/TransactionServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Domain\Transaction\Service;
+
+use PHPUnit\Framework\TestCase;
+
+class TransactionServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testTransactionServiceTransferSuccessful(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionServiceTransferPayerException(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionServiceTransferPayeeException(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionServiceTransferGeneralException(): void
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/Domain/Transaction/TransactionTest.php
+++ b/test/Domain/Transaction/TransactionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace HyperfTest\Domain\Transaction;
 
+use App\Domain\Transaction\Transaction;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class TransactionTest extends TestCase
@@ -15,36 +17,36 @@ class TransactionTest extends TestCase
 
     protected function tearDown(): void
     {
+        Mockery::close();
         parent::tearDown();
     }
 
     public function testTransactionTableName(): void
     {
-        $this->assertTrue(true);
+        $transaction = $this->createTransactionMock();
+        $transaction->shouldReceive('getTable')->andReturn('transaction');
+
+        $this->assertEquals('transaction', $transaction->getTable());
     }
 
     public function testTransactionFillableAttributes(): void
     {
-        $this->assertTrue(true);
+        $transaction = $this->createTransactionMock();
+        $transaction->shouldReceive('getFillable')->andReturn(['id', 'payer_id', 'payee_id', 'value']);
+
+        $this->assertEquals(['id', 'payer_id', 'payee_id', 'value'], $transaction->getFillable());
     }
 
     public function testTransactionCasts(): void
     {
-        $this->assertTrue(true);
+        $transaction = $this->createTransactionMock();
+        $transaction->shouldReceive('getCasts')->andReturn(['created_at' => 'datetime', 'updated_at' => 'datetime']);
+
+        $this->assertEquals(['created_at' => 'datetime', 'updated_at' => 'datetime'], $transaction->getCasts());
     }
 
-    public function testTransactionTimestamps(): void
+    protected function createTransactionMock()
     {
-        $this->assertTrue(true);
-    }
-
-    public function testTransactionDates(): void
-    {
-        $this->assertTrue(true);
-    }
-
-    public function testTransactionHasUlidsTrait(): void
-    {
-        $this->assertTrue(true);
+        return Mockery::mock(Transaction::class)->makePartial();
     }
 }

--- a/test/Domain/Transaction/TransactionTest.php
+++ b/test/Domain/Transaction/TransactionTest.php
@@ -26,7 +26,7 @@ class TransactionTest extends TestCase
         $transaction = $this->createTransactionMock();
         $transaction->shouldReceive('getTable')->andReturn('transaction');
 
-        $this->assertEquals('transaction', $transaction->getTable());
+        $this->assertSame('transaction', $transaction->getTable());
     }
 
     public function testTransactionFillableAttributes(): void
@@ -34,7 +34,7 @@ class TransactionTest extends TestCase
         $transaction = $this->createTransactionMock();
         $transaction->shouldReceive('getFillable')->andReturn(['id', 'payer_id', 'payee_id', 'value']);
 
-        $this->assertEquals(['id', 'payer_id', 'payee_id', 'value'], $transaction->getFillable());
+        $this->assertSame(['id', 'payer_id', 'payee_id', 'value'], $transaction->getFillable());
     }
 
     public function testTransactionCasts(): void
@@ -42,7 +42,7 @@ class TransactionTest extends TestCase
         $transaction = $this->createTransactionMock();
         $transaction->shouldReceive('getCasts')->andReturn(['created_at' => 'datetime', 'updated_at' => 'datetime']);
 
-        $this->assertEquals(['created_at' => 'datetime', 'updated_at' => 'datetime'], $transaction->getCasts());
+        $this->assertSame(['created_at' => 'datetime', 'updated_at' => 'datetime'], $transaction->getCasts());
     }
 
     protected function createTransactionMock()

--- a/test/Domain/Transaction/TransactionTest.php
+++ b/test/Domain/Transaction/TransactionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfTest\Domain\Transaction;
+
+use PHPUnit\Framework\TestCase;
+
+class TransactionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testTransactionTableName(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionFillableAttributes(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionCasts(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionTimestamps(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionDates(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testTransactionHasUlidsTrait(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
## What is the current behavior?
* In moment, project support only create user/common/merchant.

## What is the new behavior?
* Added transaction module with permission to make money transference between users.

## Other information:
`/api/transfer`
```json
{
    "payer": "01j10hshnhf4682yy3d2bar16w",
    "payee": "01j10hrng3fzbyww2wy1jwnfhc",
    "value": 100
}
```