### PR TITLE
fix: notification queue guzzle

### DIFF
--- a/app/Job/NotificationEmailJob.php
+++ b/app/Job/NotificationEmailJob.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Job;
 
+use App\Constants\HttpStatus;
 use Hyperf\AsyncQueue\Job;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Guzzle\ClientFactory;
+use Psr\Log\LoggerInterface;
 
 use function Hyperf\Config\config;
 
@@ -40,14 +42,21 @@ class NotificationEmailJob extends Job
         $uri = config('notification.email.uri');
 
         $container = $this->app->getContainer();
+
         $clientHttp = $container->get(ClientFactory::class);
+        $logger = $container->get(LoggerInterface::class);
 
         $request = $clientHttp->create();
-        $request->request('POST', $uri, [
+        $response = $request->post($uri, [
             'json' => [
                 'recipient' => $this->recipient,
                 'message' => $this->message,
-            ]
+            ],
+            'http_errors' => false,
         ]);
+
+        if ($response->getStatusCode() !== HttpStatus::NO_CONTENT) {
+            $logger->error($response->getBody()->getContents());
+        }
     }
 }

--- a/test/Job/NotificationEmailJobTest.php
+++ b/test/Job/NotificationEmailJobTest.php
@@ -14,6 +14,8 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class NotificationEmailJobTest extends TestCase
 {
@@ -34,17 +36,26 @@ class NotificationEmailJobTest extends TestCase
         $httpClientMock = $this->createHttpClientMock();
         $applicationContext = $this->createApplicationContextMock();
         $container = $this->createContainerMock();
+        $response = Mockery::mock(ResponseInterface::class);
+        $stream = Mockery::mock(StreamInterface::class);
 
         $applicationContext->shouldReceive('getContainer')->andReturn($container);
         $clientFactoryMock->shouldReceive('create')->andReturn($httpClientMock);
-        $httpClientMock->shouldReceive('request')
+        $httpClientMock->shouldReceive('post')
             ->once()
-            ->with('POST', $uri, [
+            ->with($uri, [
                 'json' => [
                     'recipient' => $recipient,
                     'message' => $message,
                 ],
-            ]);
+                'http_errors' => false,
+            ])->andReturn($response);
+        $response->shouldReceive('getStatusCode')->andReturn(400);
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $stream->shouldReceive('getContents')->andReturn('Error.');
+        $clientFactoryMock->shouldReceive('error')->andReturnUsing(function ($error) {
+            return $error;
+        });
         $container->shouldReceive('has')->with('Hyperf\Contract\ConfigInterface')->andReturnUsing(function () {
             return true;
         });


### PR DESCRIPTION
## What is the current behavior?
* Error throw and break in redis queue.

## What is the new behavior?
* Tratative to verify if break notification.
