### PR TITLE
fix: json status controller

### DIFF
--- a/app/Constants/HttpStatus.php
+++ b/app/Constants/HttpStatus.php
@@ -51,6 +51,16 @@ class HttpStatus extends AbstractConstants
     public const NOT_FOUND = 404;
 
     /**
+     * @Message("Conflict")
+     */
+    public const CONFLICT = 409;
+
+    /**
+     * @Message("Unprocessable Entity")
+     */
+    public const UNPROCESSABLE_ENTITY = 422;
+
+    /**
      * @Message("Internal Server Error")
      */
     public const INTERNAL_SERVER_ERROR = 500;

--- a/app/Domain/User/Controller/UserController.php
+++ b/app/Domain/User/Controller/UserController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\User\Controller;
 
+use App\Constants\HttpStatus;
 use App\Domain\User\Contract\UserServiceInterface;
 use App\Domain\User\Document\Exception\DocumentException;
 use App\Domain\User\DTO\UserDTO;
@@ -49,19 +50,19 @@ class UserController
 
             return $response
                 ->json($data)
-                ->withStatus(201);
+                ->withStatus(HttpStatus::CREATED);
         } catch (ValidationException $th) {
             return $response->json($th->errors())
-                ->withStatus(422);
+                ->withStatus(HttpStatus::UNPROCESSABLE_ENTITY);
         } catch (DocumentException $de) {
             return $response->json(['errors' => $de->getMessage()])
-                ->withStatus(422);
+                ->withStatus(HttpStatus::UNPROCESSABLE_ENTITY);
         } catch (UserExistsException $ue) {
             return $response->json(['errors' => 'Duplicated user.'])
-                ->withStatus(409);
+                ->withStatus(HttpStatus::CONFLICT);
         } catch (Throwable $th) {
             return $response->json(['errors' => 'Internal error.'])
-                ->withStatus(500);
+                ->withStatus(HttpStatus::INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/config/routes.php
+++ b/config/routes.php
@@ -17,5 +17,5 @@ use App\Domain\Transaction\Controller\TransactionController;
 use App\Domain\User\Controller\UserController;
 use Hyperf\HttpServer\Router\Router;
 
-Router::post('/api/user/register', [UserController::class, 'register']);
+Router::post('/api/user', [UserController::class, 'register']);
 Router::post('/api/transfer', [TransactionController::class, 'transfer']);

--- a/test/Domain/Transaction/Controller/TransactionControllerTest.php
+++ b/test/Domain/Transaction/Controller/TransactionControllerTest.php
@@ -42,8 +42,7 @@ class TransactionControllerTest extends TestCase
         $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturnSelf();
         $transactionService->shouldReceive('transfer')->with($transactionDTO)->andReturn(['success' => true]);
 
-        $response->shouldReceive('json')->with(null)->andReturnSelf();
-        $response->shouldReceive('withStatus')->with(200)->andReturnSelf();
+        $response->shouldReceive('withStatus')->with(204)->andReturnSelf();
 
         $controller = new TransactionController($transactionService);
         $result = $controller->transfer($request, $response, $transactionDTO);
@@ -159,7 +158,7 @@ class TransactionControllerTest extends TestCase
         $transactionDTO->shouldReceive('fromRequest')->with($request)->andReturnSelf();
         $transactionService->shouldReceive('transfer')->with($transactionDTO)->andThrow(new Exception('General error'));
 
-        $response->shouldReceive('json')->with(['errors' => 'General error'])->andReturnSelf();
+        $response->shouldReceive('json')->with(['errors' => 'Internal error.'])->andReturnSelf();
         $response->shouldReceive('withStatus')->with(500)->andReturnSelf();
 
         $controller = new TransactionController($transactionService);


### PR DESCRIPTION
## What is the current behavior?
* Return null/throwable json in controller user and transaction.

## What is the new behavior?
* Added tratatives and http status code constants.
* Route `api/user/register`, change to `api/user` 
